### PR TITLE
feat: support aweXpect repos

### DIFF
--- a/Source/Testably.Server/Controllers/PullRequestStatusCheckController.cs
+++ b/Source/Testably.Server/Controllers/PullRequestStatusCheckController.cs
@@ -61,7 +61,7 @@ public class PullRequestStatusCheckController : ControllerBase
 		}
 
 		if (pullRequestModel.Repository.Private ||
-		    RepositoryOwners.All(repositoryOwner => pullRequestModel.Repository.Owner.Login != repositoryOwner)
+		    RepositoryOwners.All(repositoryOwner => pullRequestModel.Repository.Owner.Login != repositoryOwner))
 		{
 			return BadRequest($"Only public repositories from '{string.Join(", ", RepositoryOwners)}' are supported!");
 		}

--- a/Source/Testably.Server/Controllers/PullRequestStatusCheckController.cs
+++ b/Source/Testably.Server/Controllers/PullRequestStatusCheckController.cs
@@ -12,7 +12,7 @@ namespace Testably.Server.Controllers;
 [AllowAnonymous]
 public class PullRequestStatusCheckController : ControllerBase
 {
-	private const string RepositoryOwner = "Testably";
+	private const string[] RepositoryOwners = ["Testably", "aweXpect"];
 
 	private const string SuccessMessage =
 		"The PR title must conform to the conventional commits guideline.";
@@ -61,9 +61,9 @@ public class PullRequestStatusCheckController : ControllerBase
 		}
 
 		if (pullRequestModel.Repository.Private ||
-		    pullRequestModel.Repository.Owner.Login != RepositoryOwner)
+		    RepositoryOwners.All(repositoryOwner => pullRequestModel.Repository.Owner.Login != repositoryOwner)
 		{
-			return BadRequest($"Only public repositories from '{RepositoryOwner}' are supported!");
+			return BadRequest($"Only public repositories from '{string.Join(", ", RepositoryOwners)}' are supported!");
 		}
 
 		var bearerToken = _configuration.GetValue<string>("GithubBearerToken");

--- a/Source/Testably.Server/Controllers/PullRequestStatusCheckController.cs
+++ b/Source/Testably.Server/Controllers/PullRequestStatusCheckController.cs
@@ -12,7 +12,7 @@ namespace Testably.Server.Controllers;
 [AllowAnonymous]
 public class PullRequestStatusCheckController : ControllerBase
 {
-	private const string[] RepositoryOwners = ["Testably", "aweXpect"];
+	private static readonly string[] RepositoryOwners = ["Testably", "aweXpect"];
 
 	private const string SuccessMessage =
 		"The PR title must conform to the conventional commits guideline.";


### PR DESCRIPTION
Allow webhooks from [`aweXpect`](https://github.com/aweXpect) repositories.