### PR TITLE
feat: upgrade server to .NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Source/Testably.Server/Controllers/PullRequestStatusCheckController.cs
+++ b/Source/Testably.Server/Controllers/PullRequestStatusCheckController.cs
@@ -84,7 +84,7 @@ public class PullRequestStatusCheckController : ControllerBase
 
 		using var client = _clientFactory.CreateClient("Proxied");
 		client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Testably",
-			Assembly.GetExecutingAssembly().GetName().Version.ToString()));
+			Assembly.GetExecutingAssembly().GetName().Version?.ToString()));
 		client.DefaultRequestHeaders.Authorization =
 			new AuthenticationHeaderValue("Bearer", bearerToken);
 

--- a/Source/Testably.Server/Testably.Server.csproj
+++ b/Source/Testably.Server/Testably.Server.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Tests/Testably.Server.Tests/Testably.Server.Tests.csproj
+++ b/Tests/Testably.Server.Tests/Testably.Server.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Tests/Testably.Server.Tests/Testably.Server.Tests.csproj
+++ b/Tests/Testably.Server.Tests/Testably.Server.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Moq" Version="4.20.70" />
   </ItemGroup>
 


### PR DESCRIPTION
Upgrades the Testably.Server solution and CI pipelines to target .NET 10, aligning runtime/build tooling with the new framework level.

### Changes:
- Update server and test projects to `net10.0`.
- Update Serilog package references in the server project.
- Update GitHub Actions workflows to install .NET `10.0.x`.