### PR TITLE
feat: redirect index page to documentation

### DIFF
--- a/Source/Testably.Server/Pages/Index.cshtml.cs
+++ b/Source/Testably.Server/Pages/Index.cshtml.cs
@@ -1,18 +1,10 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Logging;
 
 namespace Testably.Server.Pages;
 
 public class IndexModel : PageModel
 {
-    private readonly ILogger<IndexModel> _logger;
-
-    public IndexModel(ILogger<IndexModel> logger)
-    {
-        _logger = logger;
-    }
-
-    public void OnGet()
-    {
-    }
+    public IActionResult OnGet()
+        => RedirectPermanent("https://docs.testably.org");
 }


### PR DESCRIPTION
This pull request updates the `Index.cshtml.cs` page model to redirect users to external documentation instead of rendering the default page. The change also removes unnecessary logging code.