### PR TITLE
fix: exclude aweXpect.T6e from extensions and improve error logging

### DIFF
--- a/Pipeline/Build.Pages.cs
+++ b/Pipeline/Build.Pages.cs
@@ -49,7 +49,6 @@ partial class Build
 		new("Testably", "aweXpect.Json",         "Docs/pages",                   "extensions/project/Json",       InlineReadme: true),
 		new("Testably", "aweXpect.Mockolate",    "Docs/pages",                   "extensions/project/Mockolate",  InlineReadme: true),
 		new("Testably", "aweXpect.Reflection",   "Docs/pages",                   "extensions/project/Reflection", InlineReadme: true),
-		new("Testably", "aweXpect.T6e",          "Docs/pages",                   "extensions/project/T6e",        InlineReadme: true),
 		new("Testably", "aweXpect.Testably",     "Docs/pages",                   "extensions/project/Testably",   InlineReadme: true),
 		new("Testably", "aweXpect.Web",          "Docs/pages",                   "extensions/project/Web",        InlineReadme: true),
 		new("Testably", "Mockolate",             "Docs/pages",                   "mockolate"),
@@ -110,8 +109,9 @@ partial class Build
 		string responseContent = await response.Content.ReadAsStringAsync();
 		if (!response.IsSuccessStatusCode)
 		{
-			throw new InvalidOperationException(
-				$"Could not list '{source.SourcePath}' contents of {source.Organization}/{source.Repository}: {responseContent}");
+			Log.Warning(
+				$"Skipping {source.Organization}/{source.Repository}: could not list '{source.SourcePath}' ({(int)response.StatusCode} {response.StatusCode}): {responseContent}");
+			return;
 		}
 
 		try


### PR DESCRIPTION
This pull request makes two key changes to the documentation build pipeline. First, it removes the `aweXpect.T6e` documentation source from the list of documentation sources. Second, it improves error handling in the `DownloadDocsContent` method by logging a warning and skipping sources that cannot be listed, instead of throwing an exception and stopping the build.

**Documentation source updates:**
* Removed the `aweXpect.T6e` documentation source from the `DocsSource` records, so its documentation will no longer be processed or built.

**Error handling improvements:**
* Updated the `DownloadDocsContent` method to log a warning and skip over sources that cannot be listed, instead of throwing an exception and halting the build process. This makes the build pipeline more resilient to individual documentation source failures.