### PR TITLE
docs: prepare for new aweXpect documentation structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,4 +405,7 @@ Docs/pages/.docusaurus/
 Docs/pages/build/
 
 # Aggregated content (fetched at build time by ./build.sh Pages from sibling repositories)
-Docs/pages/docs/
+Docs/pages/docs/abstractions
+Docs/pages/docs/awexpect
+Docs/pages/docs/mockolate
+Docs/pages/docs/extensions

--- a/Pipeline/Build.Pages.cs
+++ b/Pipeline/Build.Pages.cs
@@ -44,15 +44,14 @@ partial class Build
 	/// </summary>
 	static readonly DocsSource[] AggregatedSources =
 	[
-		new("Testably", "Testably.Abstractions", "Docs/pages/docs",              "abstractions"),
-		new("Testably", "aweXpect",              "Docs/pages/docs/expectations", "awexpect"),
-		new("Testably", "aweXpect",              "Docs/pages/docs/extensions",   "extensions"),
-		new("Testably", "aweXpect.Json",         "Docs/pages",                   "extensions/project/Json",       InlineReadme: true),
-		new("Testably", "aweXpect.Mockolate",    "Docs/pages",                   "extensions/project/Mockolate",  InlineReadme: true),
-		new("Testably", "aweXpect.Reflection",   "Docs/pages",                   "extensions/project/Reflection", InlineReadme: true),
-		new("Testably", "aweXpect.Testably",     "Docs/pages",                   "extensions/project/Testably",   InlineReadme: true),
-		new("Testably", "aweXpect.Web",          "Docs/pages",                   "extensions/project/Web",        InlineReadme: true),
-		new("Testably", "Mockolate",             "Docs/pages",                   "mockolate"),
+		new("Testably", "Testably.Abstractions", "Docs/pages/docs", "abstractions"),
+		new("Testably", "aweXpect",              "Docs/pages",      "awexpect"),
+		new("Testably", "aweXpect.Json",         "Docs/pages",      "extensions/aweXpect.Json",       InlineReadme: true),
+		new("Testably", "aweXpect.Mockolate",    "Docs/pages",      "extensions/aweXpect.Mockolate",  InlineReadme: true),
+		new("Testably", "aweXpect.Reflection",   "Docs/pages",      "extensions/aweXpect.Reflection", InlineReadme: true),
+		new("Testably", "aweXpect.Testably",     "Docs/pages",      "extensions/aweXpect.Testably",   InlineReadme: true),
+		new("Testably", "aweXpect.Web",          "Docs/pages",      "extensions/aweXpect.Web",        InlineReadme: true),
+		new("Testably", "Mockolate",             "Docs/pages",      "mockolate"),
 	];
 
 	Target Pages => _ => _

--- a/Testably.Server.sln
+++ b/Testably.Server.sln
@@ -10,6 +10,12 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testably.Server.Tests", "Tests\Testably.Server.Tests\Testably.Server.Tests.csproj", "{4FA12A15-D59A-4D97-A300-0CEBEB196AAB}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{C8FAFB67-C8F7-4E23-A599-9527195C158D}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+		README.md = README.md
+		Testably.Server.sln.DotSettings = Testably.Server.sln.DotSettings
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{864BF8A5-9FCB-4C03-AC86-85D52FCB4DE2}"
 EndProject
@@ -18,6 +24,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Build", "Pipeline\Build.csproj", "{607239F0-A75D-4A0C-8653-FCB3088D6087}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Pipeline", "Pipeline", "{24AAB199-6AA0-4CEA-A522-90CA63BE30B5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +43,10 @@ Global
 		{4FA12A15-D59A-4D97-A300-0CEBEB196AAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4FA12A15-D59A-4D97-A300-0CEBEB196AAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4FA12A15-D59A-4D97-A300-0CEBEB196AAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{607239F0-A75D-4A0C-8653-FCB3088D6087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{607239F0-A75D-4A0C-8653-FCB3088D6087}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{607239F0-A75D-4A0C-8653-FCB3088D6087}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{607239F0-A75D-4A0C-8653-FCB3088D6087}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -41,6 +55,7 @@ Global
 		{4FA12A15-D59A-4D97-A300-0CEBEB196AAB} = {C37E70C5-DD52-458B-8484-331D2241AEFB}
 		{864BF8A5-9FCB-4C03-AC86-85D52FCB4DE2} = {C8FAFB67-C8F7-4E23-A599-9527195C158D}
 		{ABE451CC-9876-4E8F-8143-89571B319C13} = {864BF8A5-9FCB-4C03-AC86-85D52FCB4DE2}
+		{607239F0-A75D-4A0C-8653-FCB3088D6087} = {24AAB199-6AA0-4CEA-A522-90CA63BE30B5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BFA302B-0E80-4120-BD6E-417BADC61D01}


### PR DESCRIPTION
This pull request updates the solution structure and documentation source configuration for the project. The main changes include reorganizing documentation source paths for the `aweXpect` extensions and adding the `Pipeline` and `Build` projects to the solution, along with ensuring important solution-level files are tracked.

**Solution and Project Structure Updates:**

* Added the `Build` project (`Pipeline/Build.csproj`) and the `Pipeline` folder as projects in the solution file `Testably.Server.sln`. This includes configuration for build targets and project hierarchy.
* Included solution-level files (`.gitignore`, `LICENSE`, `README.md`, `Testably.Server.sln.DotSettings`) in the solution under a dedicated folder for better organization and visibility.

**Documentation Source Configuration:**

* Updated the `AggregatedSources` array in `Pipeline/Build.Pages.cs` to unify the documentation source paths for all `aweXpect` extensions under `Docs/pages` and adjusted destination paths to use the format `extensions/aweXpect.<ExtensionName>`. This simplifies and standardizes documentation structure.