### PR TITLE
fix: track aweXpect Migration README target rename to 10-migration.md

### DIFF
--- a/Docs/mirror-local-docs.ps1
+++ b/Docs/mirror-local-docs.ps1
@@ -38,7 +38,7 @@ $DocsRoot = Join-Path $RepoRoot "Docs/pages/docs"
 $Sources = @(
     [pscustomobject]@{ Repo="Testably.Abstractions"; SourcePath="Docs/pages/docs"; Target="Abstractions"; InlineReadme=$false; ExtraReadmes=@() }
     [pscustomobject]@{ Repo="aweXpect";              SourcePath="Docs/pages";      Target="aweXpect";     InlineReadme=$false; ExtraReadmes=@(
-        [pscustomobject]@{ Repo="aweXpect.Migration"; TargetFile="09-migration.md" }
+        [pscustomobject]@{ Repo="aweXpect.Migration"; TargetFile="10-migration.md" }
     ) }
     [pscustomobject]@{ Repo="aweXpect.Json";         SourcePath="Docs/pages";      Target="Extensions/aweXpect.Json";       InlineReadme=$true;  ExtraReadmes=@() }
     [pscustomobject]@{ Repo="aweXpect.Mockolate";    SourcePath="Docs/pages";      Target="Extensions/aweXpect.Mockolate";  InlineReadme=$true;  ExtraReadmes=@() }

--- a/Pipeline/Build.Pages.cs
+++ b/Pipeline/Build.Pages.cs
@@ -67,7 +67,7 @@ partial class Build
 		new("Testably", "aweXpect",              "Docs/pages",      "aweXpect",
 			ExtraReadmes:
 			[
-				new("Testably", "aweXpect.Migration", "09-migration.md"),
+				new("Testably", "aweXpect.Migration", "10-migration.md"),
 			]),
 		new("Testably", "aweXpect.Json",         "Docs/pages",      "Extensions/aweXpect.Json",       InlineReadme: true),
 		new("Testably", "aweXpect.Mockolate",    "Docs/pages",      "Extensions/aweXpect.Mockolate",  InlineReadme: true),


### PR DESCRIPTION
Upstream aweXpect promoted Equivalency to a top-level page, shifting Migration from 09 to 10. The substitution targeting 09-migration.md no longer matched, leaving the literal {README} placeholder in the rendered MDX and failing the Docusaurus build with "ReferenceError: README is not defined".