### PR TITLE
fix: broken link to Extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -408,5 +408,5 @@ Docs/pages/build/
 Docs/pages/docs/Abstractions
 Docs/pages/docs/aweXpect
 Docs/pages/docs/Mockolate
-Docs/pages/docs/Extensions
+Docs/pages/docs/Extensions/*/
 Docs/pages/docs/Chronology

--- a/Docs/mirror-local-docs.ps1
+++ b/Docs/mirror-local-docs.ps1
@@ -100,12 +100,11 @@ function Ensure-SidebarPosition([string]$content, [int]$position) {
     return "---`nsidebar_position: $position`n---`n`n$content"
 }
 
-if (Test-Path -LiteralPath $DocsRoot) {
-    Write-Host "Cleaning $DocsRoot"
-    Remove-Item -LiteralPath $DocsRoot -Recurse -Force
-}
 New-Item -ItemType Directory -Path $DocsRoot -Force | Out-Null
 
+# Clean each target subdirectory rather than the whole DocsRoot so that
+# site-owned overlays committed under docs/ (e.g. Extensions/index.mdx)
+# survive the mirror.
 foreach ($source in $Sources) {
     $sourceDir = Join-Path $Root (Join-Path $source.Repo $source.SourcePath)
     $targetDir = Join-Path $DocsRoot $source.Target
@@ -118,6 +117,9 @@ foreach ($source in $Sources) {
         continue
     }
 
+    if (Test-Path -LiteralPath $targetDir) {
+        Remove-Item -LiteralPath $targetDir -Recurse -Force
+    }
     New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
 
     $readmeIntro = ""

--- a/Docs/pages/docs/Extensions/index.mdx
+++ b/Docs/pages/docs/Extensions/index.mdx
@@ -1,0 +1,21 @@
+---
+title: Extensions
+sidebar_position: 0
+---
+
+# Extensions
+
+Add-on packages that extend the core Testably libraries with focused
+expectations and integrations for popular ecosystems.
+
+## aweXpect extensions
+
+- **[aweXpect.Json](./aweXpect.Json/)** — expectations for `System.Text.Json`.
+- **[aweXpect.Web](./aweXpect.Web/)** — expectations for `HttpClient` and
+  `HttpResponseMessage`.
+- **[aweXpect.Reflection](./aweXpect.Reflection/)** — expectations for
+  reflection types.
+- **[aweXpect.Testably](./aweXpect.Testably/)** — expectations for
+  Testably.Abstractions file and time systems.
+- **[aweXpect.Mockolate](./aweXpect.Mockolate/)** — expectations for
+  Mockolate mock interactions.

--- a/Pipeline/Build.Pages.cs
+++ b/Pipeline/Build.Pages.cs
@@ -88,14 +88,17 @@ partial class Build
 		.Executes(async () =>
 		{
 			AbsolutePath docsRoot = RootDirectory / "Docs" / "pages" / "docs";
-			docsRoot.CreateOrCleanDirectory();
+			docsRoot.CreateDirectory();
 
+			// Clean each target subdirectory rather than the whole docsRoot so that
+			// site-owned overlays committed under docs/ (e.g. Extensions/index.mdx)
+			// survive the build.
 			foreach (DocsSource source in AggregatedSources)
 			{
 				AbsolutePath targetDirectory = string.IsNullOrEmpty(source.TargetSubDirectory)
 					? docsRoot
 					: docsRoot / source.TargetSubDirectory;
-				targetDirectory.CreateDirectory();
+				targetDirectory.CreateOrCleanDirectory();
 				await DownloadDocsContent(source, targetDirectory);
 			}
 		});


### PR DESCRIPTION
This pull request updates the documentation build and mirroring scripts to improve how documentation directories are cleaned and to support site-owned overlays. The main changes ensure that only specific subdirectories are cleaned—rather than deleting the entire documentation root—so that custom documentation files (like overlays) are preserved. Additionally, a new Extensions documentation page is added.

**Improvements to documentation directory cleaning:**

* Changed the cleaning logic to remove only each target subdirectory instead of the whole `DocsRoot`, allowing site-owned overlays (such as `Extensions/index.mdx`) to persist after mirroring.
* Updated the build script to create the docs root directory without cleaning it, and to clean only each target subdirectory individually, preserving site-owned overlays during the build process.

**Documentation additions:**

* Added a new Extensions documentation page describing available add-on packages and their integrations.