### PR TITLE
fix: order Extensions overview first and resolve subpage links as docs

### DIFF
--- a/Docs/pages/docs/Extensions/index.mdx
+++ b/Docs/pages/docs/Extensions/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extensions
-sidebar_position: 0
+sidebar_position: -1
 ---
 
 # Extensions
@@ -10,12 +10,12 @@ expectations and integrations for popular ecosystems.
 
 ## aweXpect extensions
 
-- **[aweXpect.Json](./aweXpect.Json/)** — expectations for `System.Text.Json`.
-- **[aweXpect.Web](./aweXpect.Web/)** — expectations for `HttpClient` and
+- **[aweXpect.Json](./aweXpect.Json/index.md)** — expectations for `System.Text.Json`.
+- **[aweXpect.Web](./aweXpect.Web/index.md)** — expectations for `HttpClient` and
   `HttpResponseMessage`.
-- **[aweXpect.Reflection](./aweXpect.Reflection/)** — expectations for
+- **[aweXpect.Reflection](./aweXpect.Reflection/index.md)** — expectations for
   reflection types.
-- **[aweXpect.Testably](./aweXpect.Testably/)** — expectations for
+- **[aweXpect.Testably](./aweXpect.Testably/index.md)** — expectations for
   Testably.Abstractions file and time systems.
-- **[aweXpect.Mockolate](./aweXpect.Mockolate/)** — expectations for
+- **[aweXpect.Mockolate](./aweXpect.Mockolate/index.md)** — expectations for
   Mockolate mock interactions.


### PR DESCRIPTION
After #37, the overview rendered at the bottom of the Extensions sidebar (autogenerated categories out-sorted `sidebar_position: 0`) and the bullet links were treated as static asset URLs because of the trailing slashes. Use `sidebar_position: -1` to match the aweXpect overview and point each bullet at `./<name>/index.md` so Docusaurus resolves them as doc references.