### PR TITLE
fix(deps): bump fast-uri to 3.1.2 to resolve CVE-2026-6321 and CVE-2026-6322

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: Build
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   push:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   build:
@@ -11,35 +11,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 10.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
-    - name: Publish
-      run: dotnet publish -c Release --output ${{ github.workspace }}/publish/ Source/Testably.Site/Testably.Site.csproj
-    - name: Shutdown webpage
-      shell: pwsh
-      continue-on-error: true
-      run: |
-        try { 
-          (Invoke-WebRequest -Uri https://testably.org/lifetime/quit -Method POST -ErrorAction Stop).BaseResponse
-          Write-Information "The server was shutdown"
-          Start-Sleep -Seconds 5
-        } catch [System.Net.WebException] { 
-          Write-Warning "An exception was caught: $($_.Exception.Message)"
-        }
-    - name: Upload ftp
-      uses: sebastianpopp/ftp-action@releases/v2
-      with:
-        host: ftps://access938340810.webspace-data.io:990
-        user: ${{ secrets.FTP_USERNAME }}
-        password: ${{ secrets.FTP_PASSWORD }}
-        localDir: ${{ github.workspace }}/publish/
-        remoteDir: "."
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 10.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Test
+        run: dotnet test --no-build --verbosity normal
+      - name: Publish
+        run: dotnet publish -c Release --output ${{ github.workspace }}/publish/ Source/Testably.Site/Testably.Site.csproj
+      - name: Shutdown webpage
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          try { 
+            (Invoke-WebRequest -Uri https://testably.org/lifetime/quit -Method POST -ErrorAction Stop).BaseResponse
+            Write-Information "The server was shutdown"
+            Start-Sleep -Seconds 5
+          } catch [System.Net.WebException] { 
+            Write-Warning "An exception was caught: $($_.Exception.Message)"
+          }
+      - name: Upload ftp
+        uses: sebastianpopp/ftp-action@releases/v2
+        with:
+          host: ftps://access938340810.webspace-data.io:990
+          user: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          localDir: ${{ github.workspace }}/publish/
+          remoteDir: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 10.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 10.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Test
+        run: dotnet test --no-build --verbosity normal
+
+  build-pages:
+    name: Build Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.0.x
+      - name: Aggregate documentation from sibling repositories
+        run: ./build.sh Pages
+        env:
+          GithubToken: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ./Docs/pages/package-lock.json
+      - name: Install dependencies
+        working-directory: ./Docs/pages
+        run: npm ci --ignore-scripts
+      - name: Build website
+        working-directory: ./Docs/pages
+        run: npm run build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,50 +1,50 @@
 name: Pages
 
 on:
-    push:
-        branches: [ main ]
-        paths:
-            - 'Docs/pages/**'
-            - 'Pipeline/Build.Pages.cs'
-            - 'Pipeline/Build.Benchmarks.cs'
-            - 'Pipeline/Build.MockolateBenchmarks.cs'
-            - '.github/workflows/pages.yml'
-    repository_dispatch:
-        types: [ extension-documentation-updated-event ]
-    workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Docs/pages/**'
+      - 'Pipeline/Build.Pages.cs'
+      - 'Pipeline/Build.Benchmarks.cs'
+      - 'Pipeline/Build.MockolateBenchmarks.cs'
+      - '.github/workflows/pages.yml'
+  repository_dispatch:
+    types: [ extension-documentation-updated-event ]
+  workflow_dispatch:
 
 jobs:
-    build-pages:
-        name: Build Pages
-        runs-on: ubuntu-latest
-        permissions:
-            contents: write
-        steps:
-            -   uses: actions/checkout@v6
-                with:
-                    fetch-depth: 0
-            -   name: Setup .NET SDKs
-                uses: actions/setup-dotnet@v5
-                with:
-                    dotnet-version: |
-                        10.0.x
-            -   name: Aggregate documentation from sibling repositories
-                run: ./build.sh Pages
-                env:
-                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
-            -   uses: actions/setup-node@v6
-                with:
-                    node-version: 20
-                    cache: npm
-                    cache-dependency-path: ./Docs/pages/package-lock.json
-            -   name: Install dependencies
-                working-directory: ./Docs/pages
-                run: npm ci --ignore-scripts
-            -   name: Build website
-                working-directory: ./Docs/pages
-                run: npm run build
-            -   name: Deploy to GitHub Pages
-                uses: peaceiris/actions-gh-pages@v4
-                with:
-                    github_token: ${{ secrets.GITHUB_TOKEN }}
-                    publish_dir: ./Docs/pages/build
+  build-pages:
+    name: Build Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.0.x
+      - name: Aggregate documentation from sibling repositories
+        run: ./build.sh Pages
+        env:
+          GithubToken: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ./Docs/pages/package-lock.json
+      - name: Install dependencies
+        working-directory: ./Docs/pages
+        run: npm ci --ignore-scripts
+      - name: Build website
+        working-directory: ./Docs/pages
+        run: npm run build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./Docs/pages/build

--- a/Docs/pages/package-lock.json
+++ b/Docs/pages/package-lock.json
@@ -9420,9 +9420,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/Testably.Site.slnx
+++ b/Testably.Site.slnx
@@ -15,6 +15,7 @@
   <Folder Name="/_/.github/workflows/">
     <File Path=".github/workflows/build.yml" />
     <File Path=".github/workflows/ci.yml" />
+    <File Path=".github/workflows/pages.yml" />
   </Folder>
   <Project Path="Source/Testably.Site/Testably.Site.csproj" />
 </Solution>


### PR DESCRIPTION
Pulled in transitively via @docusaurus/core -> ... -> ajv -> fast-uri. ajv's "^3.0.1" range already accepts 3.1.2; only the lockfile pin needed refreshing.

Also adds a build-pages job to ci.yml that mirrors the deploy flow in pages.yml (./build.sh Pages -> npm ci -> npm run build) but stops before deployment.
This catches docs build regressions before they reach main.