### PR TITLE
fix(deps): bump serialize-javascript to 7.0.5 and @babel/plugin-transform-modules-systemjs to 7.29.4

### DIFF
--- a/Docs/pages/package-lock.json
+++ b/Docs/pages/package-lock.json
@@ -1229,9 +1229,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
@@ -16359,15 +16359,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17353,12 +17344,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {

--- a/Docs/pages/package.json
+++ b/Docs/pages/package.json
@@ -31,6 +31,9 @@
     "@types/react": "^19.0.0",
     "typescript": "~6.0.2"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
Resolves three Dependabot alerts in Docs/pages/package-lock.json:

- serialize-javascript RCE via RegExp.flags / Date.prototype.toISOString (GHSA-5c6j-r48x-rmvq, High; affects <=7.0.2)
- serialize-javascript CPU exhaustion DoS via crafted array-like objects (GHSA-qj8w-gfj5-8c6v, Moderate; affects <7.0.5)
- @babel/plugin-transform-modules-systemjs generates arbitrary code when compiling malicious input (GHSA-fv7c-fp4j-7gwp, High; affects >=7.12.0 <=7.29.3)

serialize-javascript needed an npm overrides entry because its parents (copy-webpack-plugin@11, css-minimizer-webpack-plugin@5) cap their constraint at ^6.0.x and there is no patched 6.x release. The babel plugin's existing ^7.29.0 range already permitted the fixed 7.29.4, so only the lockfile pin needed refreshing.

npm audit now reports 0 vulnerabilities.