### PR TITLE
feat: aggregate Testably.Abstractions.Migration into docs site

### DIFF
--- a/Docs/mirror-local-docs.ps1
+++ b/Docs/mirror-local-docs.ps1
@@ -36,8 +36,9 @@ $DocsRoot = Join-Path $RepoRoot "Docs/pages/docs"
 
 # Mirrors AggregatedSources in Pipeline/Build.Pages.cs.
 $Sources = @(
-    [pscustomobject]@{ Repo="Testably.Abstractions"; SourcePath="Docs/pages/docs"; Target="Abstractions"; InlineReadme=$false; ExtraReadmes=@() }
-    [pscustomobject]@{ Repo="aweXpect";              SourcePath="Docs/pages";      Target="aweXpect";     InlineReadme=$false; ExtraReadmes=@(
+    [pscustomobject]@{ Repo="Testably.Abstractions";           SourcePath="Docs/pages/docs"; Target="Abstractions";           InlineReadme=$false; ExtraReadmes=@() }
+    [pscustomobject]@{ Repo="Testably.Abstractions.Migration"; SourcePath="Docs/pages";      Target="Abstractions/Migration"; InlineReadme=$true;  ExtraReadmes=@() }
+    [pscustomobject]@{ Repo="aweXpect";                        SourcePath="Docs/pages";      Target="aweXpect";               InlineReadme=$false; ExtraReadmes=@(
         [pscustomobject]@{ Repo="aweXpect.Migration"; TargetFile="10-migration.md" }
     ) }
     [pscustomobject]@{ Repo="aweXpect.Json";         SourcePath="Docs/pages";      Target="Extensions/aweXpect.Json";       InlineReadme=$true;  ExtraReadmes=@() }
@@ -72,7 +73,7 @@ function Strip-ReadmeFront([string]$readme) {
 
 function Get-ReadmeIntro([string]$readmePath) {
     if (-not (Test-Path -LiteralPath $readmePath)) { return "" }
-    $content = Get-Content -Raw -LiteralPath $readmePath
+    $content = Get-Content -Raw -LiteralPath $readmePath -Encoding UTF8
     $idx = $content.IndexOf("`n##")
     if ($idx -gt 0) { return $content.Substring($idx) }
     return ""
@@ -80,7 +81,7 @@ function Get-ReadmeIntro([string]$readmePath) {
 
 function Get-ReadmeBody([string]$readmePath) {
     if (-not (Test-Path -LiteralPath $readmePath)) { return "" }
-    $content = Get-Content -Raw -LiteralPath $readmePath
+    $content = Get-Content -Raw -LiteralPath $readmePath -Encoding UTF8
     return Strip-ReadmeFront $content
 }
 
@@ -178,7 +179,7 @@ foreach ($source in $Sources) {
         $isText = $TextExt -contains $ext
 
         if ($isText) {
-            $content = Get-Content -Raw -LiteralPath $file.FullName
+            $content = Get-Content -Raw -LiteralPath $file.FullName -Encoding UTF8
             if ($null -eq $content) { $content = "" }
 
             if ($source.InlineReadme -and -not $readmeIntroDone -and $name.StartsWith("00-") -and $content.Contains("{README}")) {

--- a/Docs/mirror-local-docs.ps1
+++ b/Docs/mirror-local-docs.ps1
@@ -37,7 +37,7 @@ $DocsRoot = Join-Path $RepoRoot "Docs/pages/docs"
 # Mirrors AggregatedSources in Pipeline/Build.Pages.cs.
 $Sources = @(
     [pscustomobject]@{ Repo="Testably.Abstractions";           SourcePath="Docs/pages/docs"; Target="Abstractions";           InlineReadme=$false; ExtraReadmes=@() }
-    [pscustomobject]@{ Repo="Testably.Abstractions.Migration"; SourcePath="Docs/pages";      Target="Abstractions/Migration"; InlineReadme=$true;  ExtraReadmes=@() }
+    [pscustomobject]@{ Repo="Testably.Abstractions.Migration"; SourcePath="Docs/pages";      Target="Abstractions/migration-from-testableio/Migration"; InlineReadme=$true;  ExtraReadmes=@() }
     [pscustomobject]@{ Repo="aweXpect";                        SourcePath="Docs/pages";      Target="aweXpect";               InlineReadme=$false; ExtraReadmes=@(
         [pscustomobject]@{ Repo="aweXpect.Migration"; TargetFile="10-migration.md" }
     ) }

--- a/Pipeline/Build.Pages.cs
+++ b/Pipeline/Build.Pages.cs
@@ -63,8 +63,10 @@ partial class Build
 	/// </summary>
 	static readonly DocsSource[] AggregatedSources =
 	[
-		new("Testably", "Testably.Abstractions", "Docs/pages/docs", "Abstractions"),
-		new("Testably", "aweXpect",              "Docs/pages",      "aweXpect",
+		new("Testably", "Testably.Abstractions",           "Docs/pages/docs", "Abstractions"),
+		new("Testably", "Testably.Abstractions.Migration", "Docs/pages",      "Abstractions/Migration",
+			InlineReadme: true, Title: "Migration", SidebarPosition: 8),
+		new("Testably", "aweXpect",                        "Docs/pages",      "aweXpect",
 			ExtraReadmes:
 			[
 				new("Testably", "aweXpect.Migration", "10-migration.md"),

--- a/Pipeline/Build.Pages.cs
+++ b/Pipeline/Build.Pages.cs
@@ -64,8 +64,8 @@ partial class Build
 	static readonly DocsSource[] AggregatedSources =
 	[
 		new("Testably", "Testably.Abstractions",           "Docs/pages/docs", "Abstractions"),
-		new("Testably", "Testably.Abstractions.Migration", "Docs/pages",      "Abstractions/Migration",
-			InlineReadme: true, Title: "Migration", SidebarPosition: 8),
+		new("Testably", "Testably.Abstractions.Migration", "Docs/pages",      "Abstractions/migration-from-testableio/Migration",
+			InlineReadme: true),
 		new("Testably", "aweXpect",                        "Docs/pages",      "aweXpect",
 			ExtraReadmes:
 			[


### PR DESCRIPTION
Add the migration package's documentation as a separate slice under `docs/Abstractions/Migration/`, matching the `PackageProjectUrl` of `docs.testably.org/Abstractions/Migration`. The migration repo ships its content as a `Docs/pages/00-index.md` with `{README}` placeholder, so it slots into the existing `InlineReadme: true` flow.

Placed immediately after the `Testably.Abstractions` slice so its clean-and-populate pass on `docs/Abstractions/` runs before this slice creates `docs/Abstractions/Migration/`; otherwise the parent's clean would wipe the subdirectory.

Other migration packages (aweXpect.Migration, Mockolate.Migration) follow the `ExtraReadmes` convention where the parent library owns a placeholder page. Using a separate slice here keeps the change self-contained to this repo, since the upstream Testably.Abstractions docs do not yet expose a placeholder file.