### PR TITLE
fix: strip leading UTF-8 BOM from aggregated GitHub content

### DIFF
--- a/Pipeline/Build.Pages.cs
+++ b/Pipeline/Build.Pages.cs
@@ -339,6 +339,11 @@ partial class Build
 	static string Base64Decode(string base64EncodedData)
 	{
 		byte[] base64EncodedBytes = Convert.FromBase64String(base64EncodedData);
-		return Encoding.UTF8.GetString(base64EncodedBytes);
+		// The GitHub API returns file bytes verbatim, so a UTF-8 BOM survives into the
+		// decoded string. A leading BOM (U+FEFF) before the first markdown heading stops
+		// Docusaurus from parsing it (the heading renders as a literal paragraph) and also
+		// breaks StripReadmeFront's H1 detection, since char.IsWhiteSpace('﻿') is false
+		// and TrimStart() leaves it in place. Drop it once at the single decode chokepoint.
+		return Encoding.UTF8.GetString(base64EncodedBytes).TrimStart('﻿');
 	}
 }


### PR DESCRIPTION
The GitHub API returns file bytes verbatim, so a UTF-8 BOM in a source file (e.g. an extension's Docs/pages/00-index.md) survived decoding and landed at the start of the rendered page. A leading BOM before the first markdown heading stops Docusaurus from parsing it (the heading renders as a literal paragraph) and also breaks StripReadmeFront's H1 detection, since char.IsWhiteSpace(U+FEFF) is false. Drop it once at the single Base64Decode chokepoint so every aggregated file and README is BOM-free.